### PR TITLE
Fix the `UnicodeDecodeError` in `np.loadtxt`

### DIFF
--- a/download_imgur5k.py
+++ b/download_imgur5k.py
@@ -114,7 +114,7 @@ def main():
     # Format: { "index_id" : {indexes}, "index_to_annotation_map" : { annotations ids for an index}, "annotation_id": { each annotation's info } }
     # Bounding boxes with '.' mean the annotations were not done for various reasons
 
-    _F = np.loadtxt(f'{args.dataset_info_dir}/imgur5k_data.lst', delimiter="\t", dtype=np.str)
+    _F = np.loadtxt(f'{args.dataset_info_dir}/imgur5k_data.lst', delimiter="\t", dtype=np.str, encoding="utf-8")
     anno_json = {}
 
     anno_json['index_id'] = {}


### PR DESCRIPTION
(This is a corrected version of PR #8)

On Windows 10 `np.loadtxt` raises `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1983: character maps to <undefined>`. 
On CentOS 7: `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 858: ordinal not in range(128)`

Specifying the UTF-8 encoding fixes the problem. Tested on Windows 10 and CentOS 7.

In contributing guidelines you ask for tests. But I'm not sure what kind of tests should I add since there are no other tests in the repo. Happy to do that if you clarify this point. I completed the CLA.